### PR TITLE
Fix door interaction inspection

### DIFF
--- a/src/main/java/net/coreprotect/bukkit/Bukkit_v1_20.java
+++ b/src/main/java/net/coreprotect/bukkit/Bukkit_v1_20.java
@@ -71,6 +71,8 @@ public class Bukkit_v1_20 extends Bukkit_v1_19 {
 
         // Add all doors from tag
         addMissingTaggedBlocks(Tag.DOORS.getValues(), BlockGroup.DOORS);
+        addMissingTaggedBlocks(Tag.DOORS.getValues(), BlockGroup.INTERACT_BLOCKS);
+        addMissingTaggedBlocks(Tag.DOORS.getValues(), BlockGroup.SAFE_INTERACT_BLOCKS);
 
         // Add all fence gates to interaction blocks
         addMissingTaggedBlocks(Tag.FENCE_GATES.getValues(), BlockGroup.INTERACT_BLOCKS);

--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractListener.java
@@ -19,14 +19,12 @@ import org.bukkit.block.Jukebox;
 import org.bukkit.block.Sign;
 import org.bukkit.block.data.Bisected;
 import org.bukkit.block.data.Bisected.Half;
-import org.bukkit.block.data.SideChaining.ChainPart;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Lightable;
 import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Bed;
 import org.bukkit.block.data.type.Bed.Part;
 import org.bukkit.block.data.type.Cake;
-import org.bukkit.block.data.type.Shelf;
 import org.bukkit.entity.EnderCrystal;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -40,7 +38,6 @@ import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.util.Vector;
 
 import net.coreprotect.CoreProtect;
 import net.coreprotect.bukkit.BukkitAdapter;
@@ -214,15 +211,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
                     }
                     else if (isInteractBlock) {
                         // standard player interactions
-                        Block interactBlock = clickedBlock;
-                        if (BlockGroup.DOORS.contains(type)) {
-                            int y = interactBlock.getY() - 1;
-                            Block blockUnder = interactBlock.getWorld().getBlockAt(interactBlock.getX(), y, interactBlock.getZ());
-
-                            if (blockUnder.getType().equals(type)) {
-                                interactBlock = blockUnder;
-                            }
-                        }
+                        Block interactBlock = PlayerInteractUtils.getInteractionBlock(clickedBlock);
 
                         interactionInspector.performInteractionLookup(player, interactBlock);
 
@@ -369,16 +358,7 @@ public final class PlayerInteractListener extends Queue implements Listener {
                     }
                     else if (BlockGroup.INTERACT_BLOCKS.contains(type)) {
                         if (event.getHand().equals(EquipmentSlot.HAND) && Config.getConfig(world).PLAYER_INTERACTIONS) {
-                            Block interactBlock = event.getClickedBlock();
-                            if (BlockGroup.DOORS.contains(type)) {
-                                int y = interactBlock.getY() - 1;
-                                Block blockUnder = interactBlock.getWorld().getBlockAt(interactBlock.getX(), y, interactBlock.getZ());
-
-                                if (blockUnder.getType().equals(type)) {
-                                    interactBlock = blockUnder;
-                                }
-                            }
-
+                            Block interactBlock = PlayerInteractUtils.getInteractionBlock(event.getClickedBlock());
                             Queue.queuePlayerInteraction(player.getName(), interactBlock.getState(), type);
                         }
                     }
@@ -526,48 +506,9 @@ public final class PlayerInteractListener extends Queue implements Listener {
                                 InventoryChangeListener.inventoryTransaction(player.getName(), blockState.getLocation(), null);
                             }
                         }
-                    } else if (BukkitAdapter.ADAPTER.isShelf(type) ){
-                        BlockData blockState = block.getBlockData();  
-                        if (blockState instanceof Shelf){
-                            Shelf shelf = (Shelf) blockState;
-                        
-                        // ignore clicking on the back face
-                        if (event.getBlockFace() != shelf.getFacing()){
-                            return;
-                        }
-
-                        if (shelf.getSideChain() == ChainPart.UNCONNECTED){
-                            InventoryChangeListener.inventoryTransaction(player.getName(), block.getLocation(), null);
-                        } else {
-                            Block center = block;
-                            Vector direction = shelf.getFacing().getDirection();
-                            
-                                if (shelf.getSideChain() == ChainPart.LEFT){
-                                    center = center.getRelative(direction.getBlockZ(), 0, -direction.getBlockX());
-                                } else if (shelf.getSideChain() == ChainPart.RIGHT){
-                                    center = center.getRelative(-direction.getBlockZ(), 0, direction.getBlockX());
-                                }
-
-                                BlockData centerBlockData = center.getBlockData();
-                                if (centerBlockData instanceof Shelf){
-                                    // log center
-                                    InventoryChangeListener.inventoryTransaction(player.getName(), center.getLocation(), null);
-
-                                    if (((Shelf)centerBlockData).getSideChain() != ChainPart.CENTER){
-                                        // if it's not the center it's just a chain of 2
-                                        InventoryChangeListener.inventoryTransaction(player.getName(), block.getLocation(), null);
-                                    } else {
-                                        Block left = center.getRelative(-direction.getBlockZ(), 0, direction.getBlockX());
-                                        InventoryChangeListener.inventoryTransaction(player.getName(), left.getLocation(), null);
-                                        
-                                        Block right = center.getRelative(direction.getBlockZ(), 0, -direction.getBlockX());
-                                        InventoryChangeListener.inventoryTransaction(player.getName(), right.getLocation(), null); 
-                                    }
-                                } else {
-                                    // fallback if invalid block is found just log clicked shelf
-                                    InventoryChangeListener.inventoryTransaction(player.getName(), block.getLocation(), null);
-                                }    
-                            } 
+                    } else if (BukkitAdapter.ADAPTER.isShelf(type)) {
+                        for (Location location : BukkitAdapter.ADAPTER.getShelfInteractionLocations(block, event.getBlockFace())) {
+                            InventoryChangeListener.inventoryTransaction(player.getName(), location, null);
                         }
                     }
                     else if (BukkitAdapter.ADAPTER.isDecoratedPot(type)) {

--- a/src/main/java/net/coreprotect/listener/player/PlayerInteractUtils.java
+++ b/src/main/java/net/coreprotect/listener/player/PlayerInteractUtils.java
@@ -7,6 +7,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import net.coreprotect.thread.CacheHandler;
+import net.coreprotect.model.BlockGroup;
 import net.coreprotect.utility.WorldUtils;
 
 public final class PlayerInteractUtils {
@@ -24,6 +25,17 @@ public final class PlayerInteractUtils {
         int z = location.getBlockZ();
         String coordinates = x + "." + y + "." + z + "." + wid + "." + Material.DRAGON_EGG.name();
         CacheHandler.interactCache.put(coordinates, new Object[] { time, Material.DRAGON_EGG, player.getName() });
+    }
+
+    public static Block getInteractionBlock(Block clickedBlock) {
+        Material type = clickedBlock.getType();
+        if (BlockGroup.DOORS.contains(type)) {
+            Block blockBelow = clickedBlock.getRelative(0, -1, 0);
+            if (blockBelow.getType() == type) {
+                return blockBelow;
+            }
+        }
+        return clickedBlock;
     }
 
     public static void handleBisectedBlockVisualization(Player player, Block block, World world) {


### PR DESCRIPTION
## Summary

- Add all Bukkit `Tag.DOORS` values to `BlockGroup.DOORS`, `INTERACT_BLOCKS`, and `SAFE_INTERACT_BLOCKS` during version adapter initialization.
- Resolve either half of a door to the lower interaction block through a shared `PlayerInteractUtils` helper.
- Use the same normalized block for logging and `/co i` inspection.

## Problem

Door click rows were correctly stored and visible through `/co lookup`, but `/co i` returned `No data found`. After version-specific block-group initialization, doors were present in `BlockGroup.DOORS` but missing from the interaction groups, so the inspector selected a regular block lookup instead of an interaction lookup.

## Verification

- Door clicks are visible through both `/co lookup` and `/co i` on Paper 26.1.2.
- Clicking either the upper or lower half resolves to the same interaction location.
- `gradlew build` passes.
