### PR TITLE
Initialize block groups after version adapters

### DIFF
--- a/src/main/java/net/coreprotect/bukkit/Bukkit_v1_20.java
+++ b/src/main/java/net/coreprotect/bukkit/Bukkit_v1_20.java
@@ -71,6 +71,8 @@ public class Bukkit_v1_20 extends Bukkit_v1_19 {
 
         // Add all doors from tag
         addMissingTaggedBlocks(Tag.DOORS.getValues(), BlockGroup.DOORS);
+        addMissingTaggedBlocks(Tag.DOORS.getValues(), BlockGroup.INTERACT_BLOCKS);
+        addMissingTaggedBlocks(Tag.DOORS.getValues(), BlockGroup.SAFE_INTERACT_BLOCKS);
 
         // Add all fence gates to interaction blocks
         addMissingTaggedBlocks(Tag.FENCE_GATES.getValues(), BlockGroup.INTERACT_BLOCKS);

--- a/src/main/java/net/coreprotect/config/ConfigHandler.java
+++ b/src/main/java/net/coreprotect/config/ConfigHandler.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -40,6 +41,7 @@ import net.coreprotect.database.Database;
 import net.coreprotect.database.statement.UserStatement;
 import net.coreprotect.language.Phrase;
 import net.coreprotect.listener.ListenerHandler;
+import net.coreprotect.model.BlockGroup;
 import net.coreprotect.paper.PaperAdapter;
 import net.coreprotect.patch.Patch;
 import net.coreprotect.utility.Chat;
@@ -47,7 +49,6 @@ import net.coreprotect.utility.Color;
 import net.coreprotect.utility.SystemUtils;
 import net.coreprotect.utility.VersionUtils;
 import net.coreprotect.utility.ErrorReporter;
-import oshi.hardware.CentralProcessor;
 
 public class ConfigHandler extends Queue {
 
@@ -63,7 +64,7 @@ public class ConfigHandler extends Queue {
     public static final String JAVA_VERSION = "11.0";
     public static final String MINECRAFT_VERSION = "1.16.5";
     public static final String PATCH_VERSION = "24.0";
-    public static final String LATEST_VERSION = "26.1.2";
+    public static final String LATEST_VERSION = "26.2";
     public static String path = "plugins/CoreProtect/";
     public static String sqlite = "database.db";
     public static String host = "127.0.0.1";
@@ -81,7 +82,7 @@ public class ConfigHandler extends Queue {
     public static final String BLACKLIST_FILENAME = "blacklist.txt";
 
     public static HikariDataSource hikariDataSource = null;
-    public static final CentralProcessor processorInfo = SystemUtils.getProcessorInfo();
+    public static final SystemUtils.ProcessorInfo processorInfo = SystemUtils.getProcessorInfo();
     public static final boolean isSpigot = true;
     public static final boolean isPaper = true;
     public static final boolean isFolia = VersionUtils.isFolia();
@@ -121,6 +122,7 @@ public class ConfigHandler extends Queue {
     public static Map<String, Integer> loggingItem = syncMap();
     public static ConcurrentHashMap<String, List<Object>> transactingChest = new ConcurrentHashMap<>();
     public static ConcurrentHashMap<String, List<ItemStack[]>> oldContainer = new ConcurrentHashMap<>();
+    public static ConcurrentHashMap<String, Set<String>> oldContainerViewers = new ConcurrentHashMap<>();
     public static ConcurrentHashMap<String, List<ItemStack>> itemsPickup = new ConcurrentHashMap<>();
     public static ConcurrentHashMap<String, List<ItemStack>> itemsDrop = new ConcurrentHashMap<>();
     public static ConcurrentHashMap<String, List<ItemStack>> itemsThrown = new ConcurrentHashMap<>();
@@ -167,6 +169,23 @@ public class ConfigHandler extends Queue {
                 UserStatement.loadId(connection, player.getName(), player.getUniqueId().toString());
             }
         }
+    }
+
+    public static void addOldContainerViewer(String locationSuffix, String loggingId) {
+        oldContainerViewers.compute(locationSuffix, (key, viewers) -> {
+            if (viewers == null) {
+                viewers = ConcurrentHashMap.newKeySet();
+            }
+            viewers.add(loggingId);
+            return viewers;
+        });
+    }
+
+    public static void removeOldContainerViewer(String locationSuffix, String loggingId) {
+        oldContainerViewers.computeIfPresent(locationSuffix, (key, viewers) -> {
+            viewers.remove(loggingId);
+            return viewers.isEmpty() ? null : viewers;
+        });
     }
 
     public static boolean isBlacklisted(String user) {
@@ -489,6 +508,7 @@ public class ConfigHandler extends Queue {
         try {
             BukkitAdapter.loadAdapter();
             PaperAdapter.loadAdapter();
+            BlockGroup.initialize();
             MaterialParser.loadConfiguredTags(CoreProtect.getInstance());
 
             ConfigHandler.loadConfig(); // Load (or create) the configuration file.

--- a/src/main/java/net/coreprotect/model/BlockGroup.java
+++ b/src/main/java/net/coreprotect/model/BlockGroup.java
@@ -47,7 +47,7 @@ public final class BlockGroup {
     // Same as non_solid_entity_blocks? >>Perform testing<<
     public static Set<Material> NON_ATTACHABLE = new HashSet<>(Arrays.asList(Material.AIR, Material.CAVE_AIR, Material.BARRIER, Material.CORNFLOWER, Material.LILY_OF_THE_VALLEY, Material.WITHER_ROSE, Material.SWEET_BERRY_BUSH, Material.OAK_SAPLING, Material.SPRUCE_SAPLING, Material.BIRCH_SAPLING, Material.JUNGLE_SAPLING, Material.ACACIA_SAPLING, Material.DARK_OAK_SAPLING, Material.WATER, Material.LAVA, Material.POWERED_RAIL, Material.DETECTOR_RAIL, Material.FERN, Material.DEAD_BUSH, Material.DANDELION, Material.POPPY, Material.BLUE_ORCHID, Material.ALLIUM, Material.AZURE_BLUET, Material.RED_TULIP, Material.ORANGE_TULIP, Material.WHITE_TULIP, Material.PINK_TULIP, Material.OXEYE_DAISY, Material.BROWN_MUSHROOM, Material.RED_MUSHROOM, Material.TORCH, Material.WALL_TORCH, Material.REDSTONE_WIRE, Material.LADDER, Material.RAIL, Material.LEVER, Material.REDSTONE_TORCH, Material.REDSTONE_WALL_TORCH, Material.SNOW, Material.SUGAR_CANE, Material.NETHER_PORTAL, Material.REPEATER, Material.KELP, Material.CHORUS_FLOWER, Material.CHORUS_PLANT, Material.SOUL_TORCH, Material.SOUL_WALL_TORCH));
 
-    static {
+    public static void initialize() {
         Material shortGrass = Material.getMaterial("SHORT_GRASS");
         if (shortGrass == null) {
             shortGrass = Material.getMaterial("GRASS");


### PR DESCRIPTION
## Summary

- Replace the eager static `BlockGroup` initializer with an explicit `BlockGroup.initialize()` method.
- Invoke block-group initialization after Bukkit and Paper version adapters have populated their material sets.
- Restore the same initialization order used by upstream CoreProtect.

## Problem

Door click rows were correctly stored and visible through `/co lookup`, but `/co i` returned `No data found`. The old fork initialized derived block groups before version adapters replaced their material sets. As a result, doors were absent from `INTERACT_BLOCKS`, so the inspector selected a regular block lookup instead of an interaction lookup.

## Verification

- Door clicks are visible through both `/co lookup` and `/co i` on Paper 26.1.2.
- Door logging and inspection use the existing upstream listener logic without material-name special cases.
- `gradlew build` passes.
